### PR TITLE
Improve container image

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,8 @@ tokio-test = "0.4"
 [[bench]]
 name = "bench"
 harness = false
+
+[profile.release]
+lto = true
+strip = true
+codegen-units = 1

--- a/src/bin/healthcheck.rs
+++ b/src/bin/healthcheck.rs
@@ -1,0 +1,22 @@
+use std::{
+    env,
+    io::{Read, Write},
+    net::TcpStream,
+};
+
+fn main() {
+    let port = env::var("HOST")
+        .unwrap_or("80".to_string())
+        .parse::<u16>()
+        .expect("valid port (u16)");
+
+    let mut stream = TcpStream::connect(("127.0.0.1", port)).expect("tcp connect");
+
+    let data = "GET /health HTTP/1.1\r\n\r\n";
+    stream.write_all(data.as_bytes()).expect("write data");
+
+    let mut buffer = [0; 12];
+    stream.read(&mut buffer).expect("read data");
+
+    assert!(buffer == "HTTP/1.1 200".as_bytes(), "response is not ok");
+}

--- a/src/bin/healthcheck.rs
+++ b/src/bin/healthcheck.rs
@@ -16,7 +16,7 @@ fn main() {
     stream.write_all(data.as_bytes()).expect("write data");
 
     let mut buffer = [0; 12];
-    stream.read(&mut buffer).expect("read data");
+    stream.read_exact(&mut buffer).expect("read data");
 
     assert!(buffer == "HTTP/1.1 200".as_bytes(), "response is not ok");
 }


### PR DESCRIPTION
Here's some small improvements to the container image:

- Add a healthcheck
- Decrease size from 82.4 MiB -> 2.3 MiB
- Run as a non-root user (1000) by default

Using the `PROFILE` build arg you can also build the container for the `debug` profile (or any other, should you have others).