### PR TITLE
gracefully shutdown on control+c/SIGINT

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/ayubun/snowflake-id-worker"
 homepage = "https://github.com/ayubun/snowflake-id-worker"
 documentation = "https://github.com/ayubun/snowflake-id-worker"
 description = "A Rust worker that serves an HTTP API to generate snowflake IDs using the Twitter snowflake algorithm"
+default-run = "snowflake-id-worker"
 
 [lib]
 name = "snowflake_id_worker"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,34 @@ pub async fn run_worker() {
         .await;
 }
 
+/// Returns a future which will resolve when Ctrl-C is received.
+///
+/// Useful to know when the process should begin its cleanup and graceful shutdown.
+#[cfg(windows)]
+pub async fn exit_signal() {
+    tokio::signal::ctrl_c().await;
+}
+
+/// Returns a future which will resolve when SIGINT/SIGTERM are sent to the process.
+///
+/// Useful to know when the process should begin its cleanup and graceful shutdown.
+#[cfg(unix)]
+pub async fn exit_signal() {
+    use tokio::signal::unix::{Signal, SignalKind};
+
+    let mut term = create_signal(SignalKind::terminate());
+    let mut ctrl_c = create_signal(SignalKind::interrupt());
+
+    tokio::select! {
+        _ = term.recv() => {},
+        _ = ctrl_c.recv() => {},
+    }
+
+    fn create_signal(kind: SignalKind) -> Signal {
+        tokio::signal::unix::signal(kind).expect("couldn't create signal.")
+    }
+}
+
 pub fn create_routes() -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
     // NOTE(ayubun): I'm not certain if Arc<Mutex<SnowflakeIdGenerator>> is the best way to go
     // about this, so if any onlookers have a more clever idea, please open a pull request or issue <3

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,4 @@
-use snowflake_id_worker::run_worker;
-use tokio::signal;
+use snowflake_id_worker::{exit_signal, run_worker};
 
 #[tokio::main]
 async fn main() {
@@ -7,12 +6,9 @@ async fn main() {
         run_worker().await;
     });
 
-    match signal::ctrl_c().await {
-        Ok(()) => {},
-        Err(err) => {
-            eprintln!("Unable to listen for shutdown signal: {}", err);
-            // we also shut down in case of error
-        },
+    match exit_signal().await {
+        () => {},
+        
     }
     handle.abort();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,13 +2,8 @@ use snowflake_id_worker::{exit_signal, run_worker};
 
 #[tokio::main]
 async fn main() {
-    let handle = tokio::spawn(async {
-        run_worker().await;
-    });
-
-    match exit_signal().await {
-        () => {},
-        
-    }
-    handle.abort();
+    tokio::select!(
+        _ = exit_signal() => println!("Exiting from signal"),
+        _ = run_worker() => println!("Worker exited"),
+    )
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,18 @@
 use snowflake_id_worker::run_worker;
+use tokio::signal;
 
 #[tokio::main]
 async fn main() {
-    run_worker().await;
+    let handle = tokio::spawn(async {
+        run_worker().await;
+    });
+
+    match signal::ctrl_c().await {
+        Ok(()) => {},
+        Err(err) => {
+            eprintln!("Unable to listen for shutdown signal: {}", err);
+            // we also shut down in case of error
+        },
+    }
+    handle.abort();
 }


### PR DESCRIPTION
This PR enables graceful shutdowns - particularly when you use control+c. Previously, a SIGINT signal would not kill the service, which meant that certain service managers that weren't docker native (which tend to use signals instead of `docker kill`) would be unable to stop running the service.
 
Code mostly stolen from [the tokio documentation directly](https://tokio.rs/tokio/topics/shutdown)

running locally:
<img width="1039" height="104" alt="Screenshot 2025-07-15 at 10 17 51 PM" src="https://github.com/user-attachments/assets/2d235c73-34ac-4941-b3ef-c7cc47c78d10" />